### PR TITLE
Add Danmaku-related Toggle and Inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ ${录制目标文件夹}
 
 [只录播，不上传](https://github.com/valkjsaaa/auto-bilibili-recorder/blob/master/example_dir/recorder_config.record_only.yaml)
 
+[只录播不上传，支持弹幕相关自定义选项](https://github.com/valkjsaaa/auto-bilibili-recorder/blob/master/example_dir/recorder_config.record_only_customize.yaml)
+
 [多个直播间，多个账号](https://github.com/valkjsaaa/auto-bilibili-recorder/blob/master/example_dir/recorder_config.multi_uploader.yaml)
 
 [用户名密码登陆，使用代理（目前暂时不可用）](https://github.com/valkjsaaa/auto-bilibili-recorder/blob/master/example_dir/recorder_config.password_proxy.yaml)

--- a/example_dir/recorder_config.record_only_customize.yaml
+++ b/example_dir/recorder_config.record_only_customize.yaml
@@ -1,0 +1,6 @@
+accounts: {}
+rooms: # 所有需要录制的直播间
+  - id: 22603245        # 需要上传的直播间 ID，请填写完整号码，而不是短号，否则可能不会上传                          
+    burn_danmaku: False           # （不上传情况下）是否压制带有高能条与弹幕的视频，默认为True。选择False仅生成原始录制视频，适合使用本地播放器挂载录制结束后生成的.ass文件观看。
+    danmaku_font_size: 50        # 弹幕字体相对大小，默认为55，仅支持整数。
+    danmaku_show_name: False # 弹幕是否显示发送者用户名，默认为True。选择False更贴近B站直播间风格。

--- a/record_upload_manager.py
+++ b/record_upload_manager.py
@@ -165,8 +165,9 @@ class RecordUploadManager:
         if room_config.uploader is None:
             print(f"No need to upload for {room_config.id}")
             await session.gen_early_video()
-            await asyncio.sleep(WAIT_SESSION_MINUTES * 60)
-            await session.gen_danmaku_video()
+            if room_config.burn_danmaku:
+                await asyncio.sleep(WAIT_SESSION_MINUTES * 60)
+                await session.gen_danmaku_video()
             return
         uploader: UploaderAccount = self.config.accounts[room_config.uploader]
         substitute_dict = {

--- a/recorder_config.py
+++ b/recorder_config.py
@@ -62,11 +62,17 @@ class RecoderRoom:
     source: Optional[str]
     he_user_dict: Optional[str]
     he_regex_rules: Optional[str]
-
+    burn_danmaku: Optional[bool]
+    danmaku_font_size: Optional[int]
+    danmaku_show_usrname: Optional[bool]
+    
     def __init__(self, config_dict):
         self.uploader = None
         self.he_user_dict = None
         self.he_regex_rules = None
+        self.burn_danmaku = True
+        self.danmaku_font_size = 55
+        self.danmaku_show_name = True
         for key, value in config_dict.items():
             self.__setattr__(key, value)
 

--- a/session.py
+++ b/session.py
@@ -223,7 +223,7 @@ class Session:
 
     async def process_danmaku(self):
         video_res_x, video_res_y = self.get_resolution()
-        font_size = max(video_res_x, video_res_y) * 55 // 1920
+        font_size = max(video_res_x, video_res_y) * self.room_config.danmaku_font_size // 1920
         print(f"font_size: {font_size}")
         danmaku_conversion_command = \
             f"{BINARY_PATH}DanmakuFactory/DanmakuFactory " \
@@ -232,7 +232,7 @@ class Session:
             f"--ignore-warnings " \
             f"-o \"{self.output_path()['ass']}\" " \
             f"-i \"{self.output_path()['clean_xml']}\" " \
-            f"--fontname \"Noto Sans CJK SC\" -S {font_size} -O 255 -L 1 -D 1 --showusernames true --showmsgbox false" \
+            f"--fontname \"Noto Sans CJK SC\" -S {font_size} -O 255 -L 1 -D 1 --showusernames {self.room_config.danmaku_show_name} --showmsgbox false" \
             f">> \"{self.output_path()['extras_log']}\" 2>&1"
         await async_wait_output(danmaku_conversion_command)
 


### PR DESCRIPTION
Add two optional inputs for DanmakuFactory command used in session.py and a toggle for burning video with high-energy bar and danmaku in record-only mode. All three arguments can be configured in recorder_config.yaml under 'rooms' seciton, an example config file is added.

Backward Compatibility: Default values are added to recorder_config.py so that nothing will be affected if above three arguemnts are not specified in config file.